### PR TITLE
Simplify PlatformIO configuration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,85 +23,85 @@ default_envs = VARIANT_PWM         ; Variant for RC-Remotes with PWM signal
 
 ;================================================================
 
-[env:VARIANT_ADC]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
+;[env:VARIANT_ADC]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;; Serial Port settings (make sure the COM port is correct)
+;monitor_port    = COM5
+;monitor_speed   = 115200
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_ADC
+;
+;;================================================================
 
-; Serial Port settings (make sure the COM port is correct)
-monitor_port    = COM5
-monitor_speed   = 115200
+;[env:VARIANT_USART]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;; Serial Port settings (make sure the COM port is correct)
+;monitor_port    = COM5
+;monitor_speed   = 115200
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_USART
+;
+;;================================================================
 
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_ADC
+;[env:VARIANT_NUNCHUK]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_NUNCHUK
+;
+;;================================================================
 
-;================================================================
-
-[env:VARIANT_USART]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-; Serial Port settings (make sure the COM port is correct)
-monitor_port    = COM5
-monitor_speed   = 115200
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_USART
-
-;================================================================
-
-[env:VARIANT_NUNCHUK]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_NUNCHUK
-
-;================================================================
-
-[env:VARIANT_PPM]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_PPM
-
-;================================================================
+;[env:VARIANT_PPM]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_PPM
+;
+;;================================================================
 
 [env:VARIANT_PWM]
 platform        = ststm32
@@ -134,93 +134,93 @@ build_flags =
     ; -I./Drivers/CMSIS/Include
 ;================================================================
 
-[env:VARIANT_IBUS]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_IBUS
-
-;================================================================
-
-[env:VARIANT_HOVERCAR]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_HOVERCAR
-
-;================================================================
-
-[env:VARIANT_HOVERBOARD]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_HOVERBOARD
-
-;================================================================
-
-[env:VARIANT_TRANSPOTTER]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_TRANSPOTTER
-    
-;================================================================
-
-
-[env:VARIANT_SKATEBOARD]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -T./STM32F103RCTx_FLASH.ld
-    -lc
-    -lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-    -D VARIANT_SKATEBOARD
-    
-;================================================================
+;[env:VARIANT_IBUS]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_IBUS
+;
+;;================================================================
+;
+;[env:VARIANT_HOVERCAR]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_HOVERCAR
+;
+;;================================================================
+;
+;[env:VARIANT_HOVERBOARD]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_HOVERBOARD
+;
+;;================================================================
+;
+;[env:VARIANT_TRANSPOTTER]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_TRANSPOTTER
+;    
+;;================================================================
+;
+;
+;[env:VARIANT_SKATEBOARD]
+;platform        = ststm32
+;framework       = stm32cube
+;board           = genericSTM32F103RC
+;debug_tool      = stlink
+;upload_protocol = stlink
+;
+;build_flags =
+;    -DUSE_HAL_DRIVER
+;    -DSTM32F103xE
+;    -T./STM32F103RCTx_FLASH.ld
+;    -lc
+;    -lm
+;    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+;    -D VARIANT_SKATEBOARD
+;    
+;;================================================================


### PR DESCRIPTION
## Summary
- comment out unused environment sections in `platformio.ini`

## Testing
- `platformio run -e VARIANT_PWM` *(fails: HTTPClientError due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_686ee114a7ec832e9b31d63ada7fe040